### PR TITLE
Revert "Allow headers to be specified on a per request basis"

### DIFF
--- a/gql/transport/requests.py
+++ b/gql/transport/requests.py
@@ -20,19 +20,16 @@ class RequestsHTTPTransport(HTTPTransport):
         self.default_timeout = timeout
         self.use_json = use_json
 
-    def execute(self, document, variable_values=None, timeout=None, headers={}):
+    def execute(self, document, variable_values=None, timeout=None):
         query_str = print_ast(document)
         payload = {
             'query': query_str,
             'variables': variable_values or {}
         }
 
-        merged_headers = self.headers.copy() if self.headers else {}
-        merged_headers.update(headers)
-
         data_key = 'json' if self.use_json else 'data'
         post_args = {
-            'headers': merged_headers,
+            'headers': self.headers,
             'auth': self.auth,
             'cookies': self.cookies,
             'timeout': timeout or self.default_timeout,


### PR DESCRIPTION
Reverts wavemm/gql#2

After some discussion, we decided that it is best not to specify headers on a per request basis, since this breaks the abstraction boundary between the transport and the client. The transport should be responsible for supplying the headers (and some transports do not have headers) so we should not change the public interface of the gql.Client.execute function. This should also make it easier for our changes to be merged in upstream later.